### PR TITLE
#12 - Create a function to save the logs in a file automatically

### DIFF
--- a/checkit/__main__.py
+++ b/checkit/__main__.py
@@ -1,12 +1,21 @@
 import argparse
+import sys
 from request_service import RequestService
 from logs import Logs
 
+def usage():
+    print("\t\t\t Checkit\n\n")
+    print("Usage: checkit -r target [-l log_file_name]")
+    print("-t --target                  - target to be requested. Required")
+    print("-l --log                     - name of the file where the logs are going to be saved. Optional")
+    print("\n\nExamples:\n checkit -t http://www.google.com")
+    print(" checkit -t http://www.facebook.com -l logs.txt")
+    sys.exit(0)
 
 def parse_args():
     parser = argparse.ArgumentParser(prog="Checkit")
     group_request = parser.add_argument_group("Request options")
-    group_request.add_argument("-r", "--request", action="store", dest="request_url",
+    group_request.add_argument("-t", "--target", action="store", dest="target_url",
                                help="Do a request to an specific url")
     group_log = parser.add_argument_group("Logs options")
     group_log.add_argument("-l", "--log", action="store", dest="log_file_name",
@@ -17,14 +26,17 @@ def parse_args():
 
 
 def main():
-    requestService = RequestService()
+    if not len(sys.argv[1:]):
+        usage()
     args = parse_args()
+
     if args.log_file_name:
         logs.write_file(filename=args.log_file_name)
-    if args.request_url:
-        requestService.get_code(url=args.request_url, logs=logs)
+    if args.target_url:
+        requestService.get_code(url=args.target_url, logs=logs)
 
 
 if __name__ == "__main__":
+    requestService = RequestService()
     logs = Logs()
     main()

--- a/checkit/__main__.py
+++ b/checkit/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 from request_service import RequestService
+from logs import Logs
 
 
 def parse_args():
@@ -7,6 +8,9 @@ def parse_args():
     group_request = parser.add_argument_group("Request options")
     group_request.add_argument("-r", "--request", action="store", dest="request_url",
                                help="Do a request to an specific url")
+    group_log = parser.add_argument_group("Logs options")
+    group_log.add_argument("-l", "--log", action="store", dest="log_file_name",
+                           help="Specify a log filename")
     args = parser.parse_args()
 
     return args
@@ -15,9 +19,12 @@ def parse_args():
 def main():
     requestService = RequestService()
     args = parse_args()
+    if args.log_file_name:
+        logs.write_file(filename=args.log_file_name)
     if args.request_url:
-        requestService.get_code(url=args.request_url)
+        requestService.get_code(url=args.request_url, logs=logs)
 
 
 if __name__ == "__main__":
+    logs = Logs()
     main()

--- a/checkit/__main__.py
+++ b/checkit/__main__.py
@@ -17,13 +17,12 @@ def usage():
 def parse_args():
     parser = argparse.ArgumentParser(prog="Checkit")
     group_request = parser.add_argument_group("Request options")
-    group_request.add_argument("-t", "--target", action="store", dest="target_url",
-                               help="Do a request to an specific url")
+    group_request.add_argument("-t", "--targets", nargs="*", type=str, default=[], action="store", dest="target_url",
+                               help="Do a requests to a list of targets")
     group_log = parser.add_argument_group("Logs options")
     group_log.add_argument("-l", "--log", action="store", dest="log_file_name",
                            help="Specify a log filename")
     args = parser.parse_args()
-
     return args
 
 
@@ -35,10 +34,12 @@ def main():
     if args.log_file_name:
         logs.write_file(filename=args.log_file_name)
     if args.target_url:
-        requestService.get_code(url=args.target_url, logs=logs)
+        requestService.addEndpoints(args.target_url)
+        print(requestService.start())
 
 
 if __name__ == "__main__":
-    requestService = RequestService()
     logs = Logs()
+    requestService = RequestService(api_name="Api_name", logs=logs)
+
     main()

--- a/checkit/__main__.py
+++ b/checkit/__main__.py
@@ -3,6 +3,7 @@ import sys
 from request_service import RequestService
 from logs import Logs
 
+
 def usage():
     print("\t\t\t Checkit\n\n")
     print("Usage: checkit -r target [-l log_file_name]")
@@ -11,6 +12,7 @@ def usage():
     print("\n\nExamples:\n checkit -t http://www.google.com")
     print(" checkit -t http://www.facebook.com -l logs.txt")
     sys.exit(0)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(prog="Checkit")

--- a/checkit/logs.py
+++ b/checkit/logs.py
@@ -7,22 +7,16 @@ class Logs():
         self.logger.setLevel(logging.DEBUG)
 
     def write_file(self, filename):
-        fh = logging.FileHandler(filename)
-        fh.setLevel(logging.DEBUG)
-        self.logger.addHandler(fh)
+        self.logger.addHandler(logging.FileHandler(filename))
 
     def info(self, message):
-        print(message)
         self.logger.info('Calling endpoint: ' + message)
-        print(self.logger.handlers)
 
     def error_status_code(self, status_code):
         self.logger.error('Error %s' % status_code)
 
-    @staticmethod
     def general_error(self, message):
         self.logger.error('Undefined Error: ' + message)
 
-    @staticmethod
     def extra_info(self, message):
         self.logger.info('Extra information: ' + message)

--- a/checkit/logs.py
+++ b/checkit/logs.py
@@ -2,21 +2,27 @@ import logging
 
 
 class Logs():
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger(__name__)
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    def write_file(self, filename):
+        fh = logging.FileHandler(filename)
+        fh.setLevel(logging.DEBUG)
+        self.logger.addHandler(fh)
+
+    def info(self, message):
+        print(message)
+        self.logger.info('Calling endpoint: ' + message)
+        print(self.logger.handlers)
+
+    def error_status_code(self, status_code):
+        self.logger.error('Error %s' % status_code)
 
     @staticmethod
-    def info(message):
-        Logs.logger.info('Calling endpoint: ' + message)
+    def general_error(self, message):
+        self.logger.error('Undefined Error: ' + message)
 
     @staticmethod
-    def error_status_code(status_code):
-        Logs.logger.error('Error %s' % status_code)
-
-    @staticmethod
-    def general_error(message):
-        Logs.logger.error('Undefined Error: ' + message)
-
-    @staticmethod
-    def extra_info(message):
-        Logs.logger.info('Extra information: ' + message)
+    def extra_info(self, message):
+        self.logger.info('Extra information: ' + message)

--- a/checkit/request_service.py
+++ b/checkit/request_service.py
@@ -5,21 +5,20 @@ import sys
 import os.path
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-from checkit.logs import Logs
-
 
 class RequestService():
-    def get_code(self, url):
+
+    def get_code(self, url, logs):
         try:
             code = urllib.request.urlopen(url).getcode()
-            Logs.info(url + " --- code response:" + str(code))
+            logs.info(url + " --- code response:" + str(code))
             return code
         except urllib.error.HTTPError as e:
-            Logs.error_status_code(e.code)
+            logs.error_status_code(e.code)
             return e.code
         except urllib.error.URLError as e:
-            Logs.general_error(e.reason)
+            logs.general_error(e.reason)
             return e.reason
         except ValueError as e:
-            Logs.general_error("".join(e.args))
+            logs.general_error("".join(e.args))
             return e.args

--- a/checkit/request_service.py
+++ b/checkit/request_service.py
@@ -20,5 +20,5 @@ class RequestService():
             logs.general_error(e.reason)
             return e.reason
         except ValueError as e:
-            logs.general_error("".join(e.args))
+            logs.general_error(message="".join(e.args))
             return e.args

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,8 @@
+import logging
 import unittest
 import sys
 import os.path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -12,56 +13,67 @@ from checkit.logs import Logs
 class RequestServiceTest(unittest.TestCase):
     def setUp(self):
         self.request = RequestService()
+        self.log = Logs()
 
-    @patch('checkit.logs.Logs.logger')
-    def test_valid_url(self, mock_logging):
-        response = self.request.get_code('http://www.google.com')
-        self.assertTrue(mock_logging.info.called)
+    def test_valid_url(self):
+        url = 'http://www.google.com'
+        message = 'Calling endpoint: ' + url + " --- code response:" + str(200)
+        self.log.logger.info = MagicMock()
+
+        response = self.request.get_code(url, self.log)
+
+        self.log.logger.info.assert_called_with(message)
         self.assertEqual(response, 200)
 
-    @patch('checkit.logs.Logs.logger')
-    def test_not_found(self, mock_logging):
-        response = self.request.get_code('http://www.github.com/sdksdjflskjflskjflsdkjflskdjfsfds')
-        self.assertTrue(mock_logging.error.called)
+    def test_not_found(self):
+        self.log.logger.error = MagicMock()
+
+        response = self.request.get_code('http://www.github.com/sdksdjflskjflskjflsdkjflskdjfsfds', self.log)
+        self.log.logger.error.assert_called_with('Error %s' % 404)
         self.assertEqual(response, 404)
 
-    @patch('checkit.logs.Logs.logger')
-    def test_invalid_url(self, mock_logging):
-        response = self.request.get_code('test')
-        self.assertTrue(mock_logging.error.called)
+    def test_invalid_url(self):
+        self.log.logger.error = MagicMock()
+
+        response = self.request.get_code('test', self.log)
+
+        self.log.logger.error.assert_called_with('Undefined Error: ' + response[0])
         self.assertEqual(response[0], "unknown url type: 'test'")
 
 
 class LogsTest(unittest.TestCase):
-    @patch('checkit.logs.Logs.logger')
-    def test_info_log(self, mock_logging):
-        Logs.info('https://www.google.com  --- code response:  200')
-        self.assertTrue(mock_logging.info.called)
-        mock_logging.info.assert_called_once_with('Calling endpoint: https://www.google.com  --- code response:  200')
 
-    @patch('checkit.logs.Logs.logger')
-    def test_error_status_code_log(self, mock_logging):
-        Logs.error_status_code('400')
-        self.assertTrue(mock_logging.error.called)
-        mock_logging.error.assert_called_once_with('Error 400')
+    def setUp(self):
+        self.log = Logs()
 
-    @patch('checkit.logs.Logs.logger')
-    def test_general_error_log(self, mock_logging):
-        Logs.general_error('Crazy error')
-        self.assertTrue(mock_logging.error.called)
-        mock_logging.error.assert_called_once_with('Undefined Error: Crazy error')
+    def test_info_log(self):
+        self.log.logger.info = MagicMock()
+        self.log.info('https://www.google.com  --- code response:  200')
+        self.log.logger.info.assert_called_once_with(
+            'Calling endpoint: https://www.google.com  --- code response:  200')
 
-    @patch('checkit.logs.Logs.logger')
-    def test_extra_info_log(self, mock_logging):
-        Logs.extra_info('Crazy extra info')
-        self.assertTrue(mock_logging.info.called)
-        mock_logging.info.assert_called_once_with('Extra information: Crazy extra info')
+    def test_error_status_code_log(self):
+        self.log.logger.error = MagicMock()
+        self.log.error_status_code('400')
+        self.log.logger.error.assert_called_once_with('Error 400')
 
-    @patch('checkit.logs.Logs.logger')
-    def test_write_file(self, mock_logging):
-        Logs.write_file('test_log_file.txt')
-        self.assertTrue(mock_logging.basicConfig.called)
-        mock_logging.basicConfig.assert_called_once_with(filename='test_log_file.txt')
+    def test_general_error_log(self):
+        self.log.logger.error = MagicMock()
+        self.log.general_error('Crazy error')
+        self.log.logger.error.assert_called_once_with('Undefined Error: Crazy error')
+
+    def test_extra_info_log(self):
+        self.log.logger.info = MagicMock()
+        self.log.extra_info('Crazy extra info')
+        self.log.logger.info.assert_called_once_with('Extra information: Crazy extra info')
+
+    def test_write_file(self):
+        filename = 'test_log_file.txt'
+        logging.FileHandler = MagicMock()
+        self.log.logger.addHandler = MagicMock()
+        self.log.write_file(filename)
+        logging.FileHandler.assert_called_once_with(filename)
+        self.log.logger.addHandler.assert_called_once_with(logging.FileHandler(filename))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,7 +2,7 @@ import logging
 import unittest
 import sys
 import os.path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -57,5 +57,11 @@ class LogsTest(unittest.TestCase):
         self.assertTrue(mock_logging.info.called)
         mock_logging.info.assert_called_once_with('Extra information: Crazy extra info')
 
+    @patch('checkit.logs.Logs.logger')
+    def test_write_file(self, mock_logging):
+        Logs.write_file('test_log_file.txt')
+        self.assertTrue(mock_logging.basicConfig.called)
+        mock_logging.basicConfig.assert_called_once_with(filename='test_log_file.txt')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With this PR, we will be able to send a parameter specifying a filename, and save the logs in that file.
I've also changed the parameters from -r --request to -t --target. I think makes more sense in that way.

Example: 
    checkit -t http://www.facebook.com -l logs.txt

----------------------------------------------------------------------------------------------------------------------------------
Editing:
Since @roselmamendes added new functionality and now we can send multiple end points, I added in the command line to send multiple end points as well.
Example:
```ssh
 $ checkit -t http://www.facebook.com http://www.google.com
 [200, 200]
 $ checkit -t http://www.github.com http://www.taringa.net -l log_file.txt
 log_file.txt:
 Calling endpoint: http://www.github.com --- code response:200
 Calling endpoint: http://www.taringa.net --- code response:200
```